### PR TITLE
Support HTTP Range Requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,12 @@ struct {
 })
 ```
 
+In addition to the default functions available, the `prefix` and `suffix` template functions are also available.  For example, the suffix function can be used to conditionally write an html element based on the file extension.
+
+```html
+{{if .Path | suffix ".mp4"}}Video{{else}}Other{{end}}
+```
+
 ## Examples
 
 Below are the example commands and files needed to run a server that, by default allows access to all files, but limits access to the `/secure` path to a limited set of users identified by their client certificate subject distinguished name.

--- a/examples/conf/template.html
+++ b/examples/conf/template.html
@@ -40,6 +40,9 @@
       <td>{{.ModTime}}</td>
       <td style="text-align:right;">{{.Size}}</td>
       <td><a href="{{.Path}}">{{.Path}}</a></td>
+      {{if or (.Path | suffix ".mp4") (.Path | suffix ".txt") (.Path | suffix ".png") }}
+      <td><a href="{{.Path}}?download=false">View</a></td>
+      {{end}}
     </tr>
     {{end}}
   </table>


### PR DESCRIPTION
Closes #11

The [spf13/afero](https://pkg.go.dev/github.com/spf13/afero?tab=doc) file system already supports HTTP range requests. 
 However, the HTTP would previously always add the "Content-Disposition" header on every file.  This header can now be turned off with the `?download=false` or `?download=0` query string.  The new `prefix` and `suffix` functions should allow a server administrator to show conditional "view" buttons when media should be shown in the browser.