### PR TITLE
Add simulate request command

### DIFF
--- a/cmd/iceberg/main.go
+++ b/cmd/iceberg/main.go
@@ -901,8 +901,6 @@ func main() {
 
 			user := policy.ParseUser(v.GetString(flagUser))
 
-			fmt.Println(user.DistinguishedName())
-
 			ok := accessPolicyDocument.Evaluate(path, user)
 			if err != nil {
 				return fmt.Errorf("error validating policy: %w", err)

--- a/cmd/iceberg/main.go
+++ b/cmd/iceberg/main.go
@@ -159,6 +159,11 @@ const (
 	flagLogPath = "log"
 	//
 	flagDryRun = "dry-run"
+	//
+	// Flags used by simulate request command
+	//
+	flagPath = "path"
+	flagUser = "user"
 )
 
 type File struct {
@@ -180,10 +185,16 @@ func initFlags(flag *pflag.FlagSet) {
 	flag.StringP(flagTemplatePath, "t", "", "path to the template file used during directory listing")
 	flag.StringP(flagLogPath, "l", "-", "path to the log output.  Defaults to stdout.")
 	flag.String(flagBehaviorNotFound, BehaviorNone, "default behavior when a file is not found.  One of: "+strings.Join(Behaviors, ","))
-	initPolicyFlags(flag)
+	initAccessPolicyFlags(flag)
 	initTimeoutFlags(flag)
 	initTLSFlags(flag)
 	flag.Bool(flagDryRun, false, "exit after checking configuration")
+}
+
+func initSimulateRequestFlags(flag *pflag.FlagSet) {
+	flag.String(flagPath, "", "path")
+	flag.StringP(flagUser, "u", "", "user")
+	initAccessPolicyFlags(flag)
 }
 
 func initTimeoutFlags(flag *pflag.FlagSet) {
@@ -200,7 +211,7 @@ func initTLSFlags(flag *pflag.FlagSet) {
 	flag.Bool(flagTLSPreferServerCipherSuites, false, "prefer server cipher suites")
 }
 
-func initPolicyFlags(flag *pflag.FlagSet) {
+func initAccessPolicyFlags(flag *pflag.FlagSet) {
 	flag.StringP(flagAccessPolicyFormat, "f", "json", "format of the policy file")
 	flag.StringP(flagAccessPolicyPath, "p", "", "path to the policy file.")
 }
@@ -293,6 +304,21 @@ func checkConfig(v *viper.Viper) error {
 	}
 	if err := checkTLSConfig(v, tls.CipherSuites()); err != nil {
 		return fmt.Errorf("error with TLS configuration: %w", err)
+	}
+	return nil
+}
+
+func checkSimulateRequestConfig(v *viper.Viper) error {
+	path := v.GetString(flagPath)
+	if len(path) == 0 {
+		return fmt.Errorf("path is missing")
+	}
+	user := v.GetString(flagUser)
+	if len(user) == 0 {
+		return fmt.Errorf("user is missing")
+	}
+	if err := checkAccessPolicyConfig(v); err != nil {
+		return err
 	}
 	return nil
 }
@@ -833,6 +859,68 @@ func main() {
 	}
 	initFlags(serveCommand.Flags())
 
+	simulateCommand := &cobra.Command{
+		Use:                   `simulate`,
+		DisableFlagsInUseLine: true,
+		Short:                 "simulate action",
+		SilenceErrors:         true,
+		SilenceUsage:          true,
+	}
+
+	simulateRequestCommand := &cobra.Command{
+		Use:                   `request [--access-policy POLICY_FILE] [--access-policy-format POLICY_FORMAT] [--user USER]`,
+		DisableFlagsInUseLine: true,
+		Short:                 "simulate a request",
+		SilenceErrors:         true,
+		SilenceUsage:          true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v, err := initViper(cmd)
+			if err != nil {
+				return fmt.Errorf("error initializing viper: %w", err)
+			}
+
+			if len(args) > 1 {
+				return cmd.Usage()
+			}
+
+			if errConfig := checkSimulateRequestConfig(v); errConfig != nil {
+				return errConfig
+			}
+
+			accessPolicyDocument, err := policy.ParseAccessPolicy(v.GetString(flagAccessPolicyPath), v.GetString(flagAccessPolicyFormat))
+			if err != nil {
+				return fmt.Errorf("error loading policy: %w", err)
+			}
+
+			err = accessPolicyDocument.Validate()
+			if err != nil {
+				return fmt.Errorf("error validating policy: %w", err)
+			}
+
+			path := v.GetString(flagPath)
+
+			user := policy.ParseUser(v.GetString(flagUser))
+
+			fmt.Println(user.DistinguishedName())
+
+			ok := accessPolicyDocument.Evaluate(path, user)
+			if err != nil {
+				return fmt.Errorf("error validating policy: %w", err)
+			}
+
+			if ok {
+				fmt.Println("allow")
+			} else {
+				fmt.Println("deny")
+			}
+
+			return nil
+		},
+	}
+	initSimulateRequestFlags(simulateRequestCommand.Flags())
+
+	simulateCommand.AddCommand(simulateRequestCommand)
+
 	versionCommand := &cobra.Command{
 		Use:                   `version`,
 		DisableFlagsInUseLine: true,
@@ -845,7 +933,7 @@ func main() {
 		},
 	}
 
-	rootCommand.AddCommand(validateAccessPolicyCommand, defaultsCommand, serveCommand, versionCommand)
+	rootCommand.AddCommand(validateAccessPolicyCommand, defaultsCommand, serveCommand, simulateCommand, versionCommand)
 
 	if err := rootCommand.Execute(); err != nil {
 		_, _ = fmt.Fprintln(os.Stderr, "iceberg: "+err.Error())

--- a/cmd/iceberg/main.go
+++ b/cmd/iceberg/main.go
@@ -902,9 +902,6 @@ func main() {
 			user := policy.ParseUser(v.GetString(flagUser))
 
 			ok := accessPolicyDocument.Evaluate(path, user)
-			if err != nil {
-				return fmt.Errorf("error validating policy: %w", err)
-			}
 
 			if ok {
 				fmt.Println("allow")

--- a/cmd/iceberg/main.go
+++ b/cmd/iceberg/main.go
@@ -868,7 +868,7 @@ func main() {
 	}
 
 	simulateRequestCommand := &cobra.Command{
-		Use:                   `request [--access-policy POLICY_FILE] [--access-policy-format POLICY_FORMAT] [--user USER]`,
+		Use:                   `request [--access-policy POLICY_FILE] [--access-policy-format POLICY_FORMAT] [--user USER] [--path PATH]`,
 		DisableFlagsInUseLine: true,
 		Short:                 "simulate a request",
 		SilenceErrors:         true,

--- a/pkg/policy/User.go
+++ b/pkg/policy/User.go
@@ -14,6 +14,16 @@ import (
 	"crypto/x509/pkix"
 )
 
+var (
+	TypeCountry            = []int{2, 5, 4, 6}
+	TypeOrganization       = []int{2, 5, 4, 10}
+	TypeOrganizationalUnit = []int{2, 5, 4, 11}
+	TypeCommonName         = []int{2, 5, 4, 3}
+	TypeLocality           = []int{2, 5, 4, 7}
+	TypeState              = []int{2, 5, 4, 8}
+	TypeEmail              = []int{1, 2, 840, 113549, 1, 9, 1}
+)
+
 type User struct {
 	Subject pkix.Name
 }
@@ -23,23 +33,80 @@ type User struct {
 func (u *User) DistinguishedName() string {
 	terms := make([]string, 0)
 	for _, n := range u.Subject.Names {
-		if n.Type.Equal([]int{2, 5, 4, 6}) {
+		if n.Type.Equal(TypeCountry) {
 			terms = append(terms, fmt.Sprintf("/C=%s", n.Value))
-		} else if n.Type.Equal([]int{2, 5, 4, 10}) {
+		} else if n.Type.Equal(TypeOrganization) {
 			terms = append(terms, fmt.Sprintf("/O=%s", n.Value))
-		} else if n.Type.Equal([]int{2, 5, 4, 11}) {
+		} else if n.Type.Equal(TypeOrganizationalUnit) {
 			terms = append(terms, fmt.Sprintf("/OU=%s", n.Value))
-		} else if n.Type.Equal([]int{2, 5, 4, 3}) {
+		} else if n.Type.Equal(TypeCommonName) {
 			terms = append(terms, fmt.Sprintf("/CN=%s", n.Value))
-		} else if n.Type.Equal([]int{2, 5, 4, 7}) {
+		} else if n.Type.Equal(TypeLocality) {
 			terms = append(terms, fmt.Sprintf("/L=%s", n.Value))
-		} else if n.Type.Equal([]int{2, 5, 4, 8}) {
+		} else if n.Type.Equal(TypeState) {
 			terms = append(terms, fmt.Sprintf("/ST=%s", n.Value))
-		} else if n.Type.Equal([]int{1, 2, 840, 113549, 1, 9, 1}) {
+		} else if n.Type.Equal(TypeEmail) {
 			terms = append(terms, fmt.Sprintf("/E=%s", n.Value))
 		} else {
 			terms = append(terms, fmt.Sprintf("/%s=%s", n.Type, n.Value))
 		}
 	}
 	return strings.Join(terms, "")
+}
+
+// ParseUser parses the the user subject as a DistinguishedName.
+// See https://docs.microsoft.com/en-us/windows/win32/seccrypto/name-properties
+// Todo: (1) fill in the other fields for the user, and (2) parse unknown names.
+func ParseUser(str string) *User {
+	terms := strings.Split(str, "/")
+	u := &User{
+		Subject: pkix.Name{
+			Names:      []pkix.AttributeTypeAndValue{},
+			ExtraNames: []pkix.AttributeTypeAndValue{},
+		},
+	}
+	for _, t := range terms {
+		if len(t) > 0 {
+			parts := strings.SplitN(t, "=", 2)
+			switch strings.ToUpper(parts[0]) {
+			case "C":
+				u.Subject.Names = append(u.Subject.Names, pkix.AttributeTypeAndValue{
+					Type:  TypeCountry,
+					Value: parts[1],
+				})
+			case "O":
+				u.Subject.Names = append(u.Subject.Names, pkix.AttributeTypeAndValue{
+					Type:  TypeOrganization,
+					Value: parts[1],
+				})
+			case "OU":
+				u.Subject.Names = append(u.Subject.Names, pkix.AttributeTypeAndValue{
+					Type:  TypeOrganizationalUnit,
+					Value: parts[1],
+				})
+			case "CN":
+				u.Subject.Names = append(u.Subject.Names, pkix.AttributeTypeAndValue{
+					Type:  TypeCommonName,
+					Value: parts[1],
+				})
+			case "L":
+				u.Subject.Names = append(u.Subject.Names, pkix.AttributeTypeAndValue{
+					Type:  TypeLocality,
+					Value: parts[1],
+				})
+			case "ST":
+				u.Subject.Names = append(u.Subject.Names, pkix.AttributeTypeAndValue{
+					Type:  TypeState,
+					Value: parts[1],
+				})
+			case "E":
+				u.Subject.Names = append(u.Subject.Names, pkix.AttributeTypeAndValue{
+					Type:  TypeEmail,
+					Value: parts[1],
+				})
+			default:
+			}
+		}
+	}
+	return u
 }


### PR DESCRIPTION
Closes #13 

This PR adds a command to simulate requests that can be used to test policies as part of a CI/CD pipeline.