### PR TITLE
CRL support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,8 +48,10 @@ jobs:
           docker_layer_caching: false
       - run: make tidy
       - run: make bin/iceberg
+      - run: openssl rand --writerand ~/.rnd
       - run: make temp/ca.crt
       - run: make temp/server.crt
+      - run: make crl
       - run: make test_cli
 
   # `build` builds the iceberg executable.

--- a/Makefile
+++ b/Makefile
@@ -99,19 +99,40 @@ temp/ca.crt:
 	mkdir -p temp
 	openssl req -x509 -nodes -days 365 -newkey rsa:2048 -subj "/C=US/O=Atlantis/OU=Atlantis Digital Service/CN=icebergca" -keyout temp/ca.key -out temp/ca.crt
 
-temp/server.crt:
-	mkdir -p temp
-	openssl req -x509 -nodes -days 365 -newkey rsa:2048  -subj "/C=US/O=Atlantis/OU=Atlantis Digital Service/CN=iceberglocal" -keyout temp/server.key -out temp/server.crt
+temp/ca.srl:
+	echo '01' > temp/ca.srl
 
-temp/client.crt: temp/ca.crt
+temp/index.txt:
+	touch temp/index.txt
+
+temp/index.txt.attr:
+	echo 'unique_subject = yes' > temp/index.txt.attr
+
+temp/server.crt: temp/ca.crt temp/ca.srl temp/index.txt temp/index.txt.attr
+	mkdir -p temp
+	openssl genrsa -out temp/server.key 2048
+	openssl req -new -key temp/server.key -subj "/C=US/O=Atlantis/OU=Atlantis Digital Service/CN=iceberglocal" -out temp/server.csr
+	openssl ca -config examples/conf/openssl.cnf -batch -notext -in temp/server.csr -out temp/server.crt
+
+temp/client.crt: temp/ca.crt temp/ca.srl temp/index.txt temp/index.txt.attr
 	mkdir -p temp
 	openssl genrsa -out temp/client.key 2048
 	openssl req -new -key temp/client.key -subj "/C=US/O=Atlantis/OU=Atlantis Digital Service/OU=CONTRACTOR/CN=LAST.FIRST.MIDDLE.ID" -out temp/client.csr
-	openssl x509 -req -in temp/client.csr -CA temp/ca.crt -CAkey temp/ca.key -CAcreateserial -out temp/client.crt
+	openssl ca -config examples/conf/openssl.cnf -notext -in temp/client.csr -out temp/client.crt
 
 temp/client.p12: temp/ca.crt temp/client.crt
 	mkdir -p temp
 	openssl pkcs12 -export -out temp/client.p12 -inkey temp/client.key -in temp/client.crt -certfile temp/ca.crt -passout pass:
+
+.PHONY: crl
+crl: temp/ca.crt temp/index.txt temp/index.txt.attr
+	rm -f temp/ca.crl.pem temp/ca.crl.der
+	openssl ca -gencrl -config examples/conf/openssl.cnf -out temp/ca.crl.pem
+	openssl crl -in temp/ca.crl.pem -outform DER -out temp/ca.crl.der
+
+.PHONY: revoke
+revoke:
+	openssl ca -config examples/conf/openssl.cnf -cert temp/ca.crt -keyfile temp/ca.key -revoke temp/client.crt
 
 ## Clean
 

--- a/README.md
+++ b/README.md
@@ -21,29 +21,31 @@ Usage:
   iceberg serve [flags]
 
 Flags:
-  -p, --access-policy string              path to the policy file.
-  -f, --access-policy-format string       format of the policy file (default "json")
-  -a, --addr string                       address that iceberg will listen on (default ":8080")
-      --behavior-not-found string         default behavior when a file is not found.  One of: redirect,none (default "none")
-      --client-ca string                  path to CA bundle for client authentication
-      --client-ca-format string           format of the CA bundle for client authentication, either pkcs7 or pem (default "pkcs7")
-      --dry-run                           exit after checking configuration
-  -h, --help                              help for serve
-  -l, --log string                        path to the log output.  Defaults to stdout. (default "-")
-      --public-location string            the public location of the server used for redirects
-      --redirect string                   address that iceberg will listen to and redirect requests to the public location
-  -r, --root string                       path to the document root served
-      --server-cert string                path to server public cert
-      --server-key string                 path to server private key
-  -t, --template string                   path to the template file used during directory listing
-      --timeout-idle string               maximum amount of time to wait for the next request when keep-alives are enabled (default "5m")
-      --timeout-read string               maximum duration for reading the entire request (default "15m")
-      --timeout-write string              maximum duration before timing out writes of the response (default "5m")
-      --tls-cipher-suites string          list of supported cipher suites for TLS versions up to 1.2 (TLS 1.3 is not configureable)
-      --tls-curve-preferences string      curve preferences (default "X25519,CurveP256,CurveP384,CurveP521")
-      --tls-max-version string            maximum TLS version accepted for requests (default "1.3")
-      --tls-min-version string            minimum TLS version accepted for requests (default "1.0")
-      --tls-prefer-server-cipher-suites   prefer server cipher suites
+-p, --access-policy string              path to the policy file.
+-f, --access-policy-format string       format of the policy file (default "json")
+-a, --addr string                       address that iceberg will listen on (default ":8080")
+    --behavior-not-found string         default behavior when a file is not found.  One of: redirect,none (default "none")
+    --client-ca string                  path to CA bundle for client authentication
+    --client-ca-format string           format of the CA bundle for client authentication, either pkcs7 or pem (default "pkcs7")
+    --client-crl string                 path to CRL bundle for client authentication
+    --client-crl-format string          format of the CRL bundle for client authentication, either der, der.zip, or pem (default "der")
+    --dry-run                           exit after checking configuration
+-h, --help                              help for serve
+-l, --log string                        path to the log output.  Defaults to stdout. (default "-")
+    --public-location string            the public location of the server used for redirects
+    --redirect string                   address that iceberg will listen to and redirect requests to the public location
+-r, --root string                       path to the document root served
+    --server-cert string                path to server public cert
+    --server-key string                 path to server private key
+-t, --template string                   path to the template file used during directory listing
+    --timeout-idle string               maximum amount of time to wait for the next request when keep-alives are enabled (default "5m")
+    --timeout-read string               maximum duration for reading the entire request (default "15m")
+    --timeout-write string              maximum duration before timing out writes of the response (default "5m")
+    --tls-cipher-suites string          list of supported cipher suites for TLS versions up to 1.2 (TLS 1.3 is not configureable)
+    --tls-curve-preferences string      curve preferences (default "X25519,CurveP256,CurveP384,CurveP521")
+    --tls-max-version string            maximum TLS version accepted for requests (default "1.3")
+    --tls-min-version string            minimum TLS version accepted for requests (default "1.0")
+    --tls-prefer-server-cipher-suites   prefer server cipher suites
 ```
 
 ### Network Encryption

--- a/examples/conf/openssl.cnf
+++ b/examples/conf/openssl.cnf
@@ -1,0 +1,58 @@
+[ ca ]
+default_ca = CA_default            # The default ca section
+
+[ CA_default ]
+
+dir            = ./temp              # top dir
+database       = ./temp/index.txt        # index file.
+new_certs_dir  = ./temp         # new certs dir
+
+certificate    = ./temp/ca.crt       # The CA cert
+serial         = ./temp/ca.srl           # serial no file
+private_key    = ./temp/ca.key# CA private key
+#RANDFILE       = ./temp/.rand    # random number file
+
+default_days   = 365                   # how long to certify for
+default_crl_days= 30                   # how long before next CRL
+default_md     = sha256                   # md to use
+
+policy         = policy_any            # default policy
+email_in_dn    = no                    # Don't add the email into cert DN
+
+name_opt       = ca_default            # Subject name display option
+cert_opt       = ca_default            # Certificate display option
+copy_extensions = copy                 # Don't copy extensions from request
+
+[ policy_any ]
+countryName            = supplied
+stateOrProvinceName    = optional
+organizationName       = optional
+organizationalUnitName = optional
+commonName             = supplied
+emailAddress           = optional
+
+[ req ]
+#default_bits		= 2048
+#default_md		= sha256
+#default_keyfile 	= privkey.pem
+distinguished_name	= req_distinguished_name
+attributes		= req_attributes
+req_extensions         = v3_ca
+
+[ req_distinguished_name ]
+countryName			= Country Name (2 letter code)
+countryName_min			= 2
+countryName_max			= 2
+stateOrProvinceName		= State or Province Name (full name)
+localityName			= Locality Name (eg, city)
+0.organizationName		= Organization Name (eg, company)
+organizationalUnitName		= Organizational Unit Name (eg, section)
+commonName			= Common Name (eg, fully qualified host name)
+commonName_max			= 64
+emailAddress			= Email Address
+emailAddress_max		= 64
+
+[ req_attributes ]
+challengePassword		= A challenge password
+challengePassword_min		= 4
+challengePassword_max		= 20

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,8 @@ require (
 	github.com/spf13/viper v1.6.3
 	github.com/stretchr/testify v1.5.1
 	go.mozilla.org/pkcs7 v0.0.0-20200128120323-432b2356ecb1
+	golang.org/x/sys v0.0.0-20190412213103-97732733099d // indirect
+	golang.org/x/text v0.3.2 // indirect
 	golang.org/x/tools v0.0.0-20190328211700-ab21143f2384
 	gopkg.in/yaml.v2 v2.2.4
 	honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099

--- a/go.sum
+++ b/go.sum
@@ -165,10 +165,15 @@ golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a h1:1BGLXjeY4akVXGgbC9HugT3Jv3hCI0z56oJR5vAMgBU=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190412213103-97732733099d h1:+R4KGOnez64A81RvjARKc4UT5/tI9ujCIVX+P5KiHuI=
+golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
+golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190328211700-ab21143f2384 h1:TFlARGu6Czu1z7q93HTxcP1P+/ZFC/IKythI5RzrnRg=

--- a/scripts/test-cli.sh
+++ b/scripts/test-cli.sh
@@ -18,7 +18,7 @@ export temp="${DIR}/../temp"
 _testServe() {
   local accessPolicy=$1
   local expected=''
-  local output=$("${DIR}/../bin/iceberg" serve --access-policy $accessPolicy --access-policy-format json --client-ca "${temp}/ca.crt" --client-ca-format pem  --root "${testdata_local}/public" --server-cert "${temp}/server.crt" --server-key "${temp}/server.key" --template "${testdata_local}/template.html" --dry-run 2>&1)
+  local output=$("${DIR}/../bin/iceberg" serve --access-policy $accessPolicy --access-policy-format json --client-ca "${temp}/ca.crt" --client-ca-format pem  --root "${testdata_local}/public" --server-cert "${temp}/server.crt" --server-key "${temp}/server.key" --template "${testdata_local}/template.html" --client-crl temp/ca.crl.der --client-crl-format der --dry-run 2>&1)
   assertEquals "unexpected output" "${expected}" "${output}"
 }
 


### PR DESCRIPTION
Closes https://github.com/deptofdefense/iceberg/issues/8

Add the `--client-crl` and `--client-crl-format` command line flags and reworks the `Makefile` targets to support the full `openssl ca` workflow instead of just using `openssl x509`.