### PR TITLE
Begin OCSP work with openssl and golang example code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ docker_serve_example: temp/ca.crt temp/server.crt ## Serve using docker server i
 
 temp/ca.crt:
 	mkdir -p temp
-	openssl req -x509 -nodes -days 365 -newkey rsa:2048 -subj "/C=US/O=Atlantis/OU=Atlantis Digital Service/CN=icebergca" -keyout temp/ca.key -out temp/ca.crt
+	openssl req -batch -x509 -nodes -days 365 -newkey rsa:2048 -subj "/C=US/O=Atlantis/OU=Atlantis Digital Service/CN=icebergca" -keyout temp/ca.key -out temp/ca.crt
 
 temp/ca.srl:
 	echo '01' > temp/ca.srl
@@ -109,7 +109,7 @@ temp/index.txt.attr:
 	echo 'unique_subject = yes' > temp/index.txt.attr
 
 temp/ca.crl.pem: temp/ca.crt temp/index.txt temp/index.txt.attr
-	openssl ca -gencrl -config examples/conf/openssl.cnf -out temp/ca.crl.pem
+	openssl ca -batch -gencrl -config examples/conf/openssl.cnf -out temp/ca.crl.pem
 
 temp/ca.crl.der: temp/ca.crl.pem
 	openssl crl -in temp/ca.crl.pem -outform DER -out temp/ca.crl.der
@@ -118,13 +118,13 @@ temp/server.crt: temp/ca.crt temp/ca.srl temp/index.txt temp/index.txt.attr
 	mkdir -p temp
 	openssl genrsa -out temp/server.key 2048
 	openssl req -new -key temp/server.key -subj "/C=US/O=Atlantis/OU=Atlantis Digital Service/CN=iceberglocal" -out temp/server.csr
-	openssl ca -config examples/conf/openssl.cnf -batch -notext -in temp/server.csr -out temp/server.crt
+	openssl ca -batch -config examples/conf/openssl.cnf -extensions server_ext -notext -in temp/server.csr -out temp/server.crt
 
 temp/client.crt: temp/ca.crt temp/ca.srl temp/index.txt temp/index.txt.attr
 	mkdir -p temp
 	openssl genrsa -out temp/client.key 2048
 	openssl req -new -key temp/client.key -subj "/C=US/O=Atlantis/OU=Atlantis Digital Service/OU=CONTRACTOR/CN=LAST.FIRST.MIDDLE.ID" -out temp/client.csr
-	openssl ca -config examples/conf/openssl.cnf -notext -in temp/client.csr -out temp/client.crt
+	openssl ca -batch -config examples/conf/openssl.cnf -extensions server_ext -notext -in temp/client.csr -out temp/client.crt
 
 temp/client.p12: temp/ca.crt temp/client.crt
 	mkdir -p temp
@@ -137,7 +137,26 @@ crl:
 
 .PHONY: revoke
 revoke:
-	openssl ca -config examples/conf/openssl.cnf -cert temp/ca.crt -keyfile temp/ca.key -revoke temp/client.crt
+	openssl ca -batch -config examples/conf/openssl.cnf -cert temp/ca.crt -keyfile temp/ca.key -revoke temp/client.crt
+
+temp/ocsp.crt: temp/ca.crt temp/ca.srl temp/index.txt temp/index.txt.attr
+	mkdir -p temp
+	openssl genrsa -out temp/ocsp.key 2048
+	openssl req -new -key temp/ocsp.key -subj "/C=US/O=Atlantis/OU=Atlantis Digital Service/OU=OCSP/CN=127.0.0.1:9999" -out temp/ocsp.csr
+	openssl ca -batch -config examples/conf/openssl.cnf -notext -in temp/ocsp.csr -out temp/ocsp.crt
+
+.PHONY: ocsp_responder
+ocsp_responder:
+	openssl ocsp -index temp/index.txt -port 9999 -rsigner temp/ocsp.crt -rkey temp/ocsp.key -CA temp/ca.crt -text -out temp/ocsp.log
+
+.PHONY: ocsp_validate_client
+ocsp_validate_client:
+	openssl ocsp -CAfile temp/ca.crt -issuer temp/ca.crt -cert temp/client.crt -url http://localhost:9999 -resp_text
+
+.PHONY: ocsp_revoke_client
+ocsp_revoke_client:
+	openssl ca -batch -config examples/conf/openssl.cnf -cert temp/ca.crt -keyfile temp/ca.key -revoke temp/client.crt
+
 
 ## Clean
 

--- a/README.md
+++ b/README.md
@@ -267,6 +267,68 @@ so select the "OK" button immediately.
 
 Now you may browse to the website at <https://iceberglocal:8080>.
 
+## Certificate Revocation
+
+### CRL
+
+TBD
+
+### OCSP
+
+OCSP is the preferred method of managing certificate revocation. In order to work with OCSP you first need to create OCSP certificate and key pair in order to run an OCSP responder server with OpenSSL. Additionally you'll need a client key to verify.
+
+```sh
+make temp/ocsp.crt temp/client.p12
+```
+
+Verify the OCSP server information is on the client certificate with:
+
+```sh
+openssl x509 -in temp/client.crt -text -noout
+```
+
+A section that looks like this should appear:
+
+```text
+        X509v3 extensions:
+            Authority Information Access: 
+                OCSP - URI:http://127.0.0.1:9999
+```
+
+Now run the OCSP responder server in another terminal
+
+```sh
+make ocsp_responder
+```
+
+Validate the client certificate with:
+
+```sh
+make ocsp_validate_client
+```
+
+Test this with golang run:
+
+```sh
+go run ./pkg/ocsp/ocsp.go
+```
+
+See the output: "Good"
+
+Now revoke the cert:
+
+```sh
+make ocsp_revoke_client
+```
+
+And run again:
+
+```sh
+go run ./pkg/ocsp/ocsp.go
+```
+
+See the output: "Revoked"
+
 ## Contributing
 
 We'd love to have your contributions!  Please see [CONTRIBUTING.md](CONTRIBUTING.md) for more info.

--- a/examples/conf/openssl.cnf
+++ b/examples/conf/openssl.cnf
@@ -56,3 +56,6 @@ emailAddress_max		= 64
 challengePassword		= A challenge password
 challengePassword_min		= 4
 challengePassword_max		= 20
+
+[ server_ext ]
+authorityInfoAccess = OCSP;URI:http://127.0.0.1:9999

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/spf13/viper v1.6.3
 	github.com/stretchr/testify v1.5.1
 	go.mozilla.org/pkcs7 v0.0.0-20200128120323-432b2356ecb1
+	golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2
 	golang.org/x/sys v0.0.0-20190412213103-97732733099d // indirect
 	golang.org/x/text v0.3.2 // indirect
 	golang.org/x/tools v0.0.0-20190328211700-ab21143f2384

--- a/go.sum
+++ b/go.sum
@@ -147,6 +147,7 @@ go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=

--- a/pkg/ocsp/ocsp.go
+++ b/pkg/ocsp/ocsp.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"bytes"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"path"
+
+	"golang.org/x/crypto/ocsp"
+)
+
+func parseCert(filename string) (*x509.Certificate, error) {
+	r, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	block, _ := pem.Decode(r)
+	cert, err := x509.ParseCertificate(block.Bytes)
+	return cert, err
+}
+
+func main() {
+
+	certDir := "./temp/"
+
+	cert, err := parseCert(path.Join(certDir, "client.crt"))
+	if err != nil {
+		panic(err)
+	}
+
+	issuer, err := parseCert(path.Join(certDir, "ca.crt"))
+	if err != nil {
+		panic(err)
+	}
+
+	if len(cert.OCSPServer) == 0 {
+		panic(errors.New("No OCSP Server listed for cert"))
+	}
+
+	ocspReq, err := ocsp.CreateRequest(cert, issuer, nil)
+	if err != nil {
+		panic(err)
+	}
+
+	req, err := http.NewRequest(
+		http.MethodPost,
+		cert.OCSPServer[0],
+		bytes.NewReader(ocspReq))
+	if err != nil {
+		panic(err)
+	}
+
+	req.Header.Set("User-Agent", "test")
+	resp, err := http.DefaultClient.Do(req)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+	if err != nil {
+		panic(err)
+	}
+
+	raw, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		panic(err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		panic(errors.New(fmt.Sprintf("Bad response %s from %q: %q", resp.StatusCode, cert.OCSPServer[0], raw)))
+	}
+
+	ocspResp, err := ocsp.ParseResponseForCert(raw, cert, issuer)
+	if err != nil {
+		if re, ok := err.(ocsp.ResponseError); ok {
+			switch re.Status {
+			case ocsp.Success:
+				fmt.Println("Success")
+			case ocsp.TryLater:
+				fmt.Println("Try Later")
+			default:
+				// Do nothing
+
+			}
+		}
+		panic(err)
+	}
+	if ocspResp == nil {
+		panic(errors.New("No OCSP Response"))
+	}
+
+	switch ocspResp.Status {
+	case ocsp.Good:
+		fmt.Println("Good")
+	case ocsp.Revoked:
+		fmt.Println("Revoked")
+	case ocsp.Unknown:
+		fmt.Println("Unknown")
+	case ocsp.ServerFailed:
+		fmt.Println("ServerFailed")
+	default:
+		panic(errors.New("OCSP status not specified"))
+	}
+
+	fmt.Println("\nStats:")
+	fmt.Printf("ProducedAt: %q\n", ocspResp.ProducedAt)
+	fmt.Printf("ThisUpdate: %q\n", ocspResp.ThisUpdate)
+	fmt.Printf("Nextupdate: %q\n", ocspResp.NextUpdate)
+	fmt.Printf("RevokedAt:  %q\n", ocspResp.RevokedAt)
+}


### PR DESCRIPTION
This PR begins with adding an OCSP example that can be done using OpenSSL commands and verified with Golang. Instructions for usage are in the `README.md`.